### PR TITLE
POC: show fill events to user

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -84,12 +84,12 @@ const Content = (): JSX.Element => {
             }
           />
           <Route
-              path="fill-events"
-              element={
-                <ProtectedRoute>
-                  <FillEvents />
-                </ProtectedRoute>
-              }
+            path="fill-events"
+            element={
+              <ProtectedRoute>
+                <FillEvents />
+              </ProtectedRoute>
+            }
           />
           <Route
             path="user"

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,6 +15,7 @@ import { UserSettings } from './components/UserSettings/UserSettings';
 import { BlenderLogbook } from './views/BlenderLogbook';
 import { ProtectedRoute } from './components/common/Auth';
 import { Logbook } from './views/Logbook';
+import { FillEvents } from './views/FillEvents';
 import { useEffect, useState } from 'react';
 import { getTokenFromLocalStorage } from './lib/utils';
 import { ToastContainer } from 'react-toastify';
@@ -81,6 +82,14 @@ const Content = (): JSX.Element => {
                 <BlenderLogbook />
               </ProtectedRoute>
             }
+          />
+          <Route
+              path="fill-events"
+              element={
+                <ProtectedRoute>
+                  <FillEvents />
+                </ProtectedRoute>
+              }
           />
           <Route
             path="user"

--- a/src/components/FillEvents/ListFillEvents.tsx
+++ b/src/components/FillEvents/ListFillEvents.tsx
@@ -1,16 +1,22 @@
 import { useFillEventQuery } from '../../lib/queries/FillEventQuery';
 import FillEvent from '../../interfaces/FillEvent';
 
-function FillEventRow ({ data, index }: { data: FillEvent, index: number }): JSX.Element {
-  return <tr
-      className={index % 2 === 0 ? 'evenRow' : 'oddRow'}
-  >
-    <td>{data.createdAt}</td>
-    <td>{data.cylinderSetName}</td>
-    <td>{data.gasMixture}</td>
-    <td>{data.description}</td>
-    <td>{data.price}</td>
-  </tr>;
+function FillEventRow({
+  data,
+  index,
+}: {
+  data: FillEvent;
+  index: number;
+}): JSX.Element {
+  return (
+    <tr className={index % 2 === 0 ? 'evenRow' : 'oddRow'}>
+      <td>{data.createdAt}</td>
+      <td>{data.cylinderSetName}</td>
+      <td>{data.gasMixture}</td>
+      <td>{data.description}</td>
+      <td>{data.price}</td>
+    </tr>
+  );
 }
 
 export const ListFillEvents = (): JSX.Element => {
@@ -22,31 +28,17 @@ export const ListFillEvents = (): JSX.Element => {
       <table className="table">
         <thead className="tableHead">
           <tr>
-            <th>
-              Päivämäärä
-            </th>
-            <th>
-              pullosetti
-            </th>
-            <th>
-              kaasuseos
-            </th>
-            <th>
-              lisätiedot
-            </th>
-            <th>
-              hinta (€)
-            </th>
+            <th>Päivämäärä</th>
+            <th>pullosetti</th>
+            <th>kaasuseos</th>
+            <th>lisätiedot</th>
+            <th>hinta (€)</th>
           </tr>
         </thead>
         <tbody>
-          {fillEvents.map((fillEvent, index) =>
-              <FillEventRow
-                  key={fillEvent.id}
-                  data={fillEvent}
-                  index={index}
-              />
-          )}
+          {fillEvents.map((fillEvent, index) => (
+            <FillEventRow key={fillEvent.id} data={fillEvent} index={index} />
+          ))}
         </tbody>
       </table>
     </div>

--- a/src/components/FillEvents/ListFillEvents.tsx
+++ b/src/components/FillEvents/ListFillEvents.tsx
@@ -1,13 +1,13 @@
 import { useFillEventQuery } from '../../lib/queries/FillEventQuery';
 import FillEvent from '../../interfaces/FillEvent';
 
-function FillEventRow({
+const FillEventRow = ({
   data,
   index,
 }: {
   data: FillEvent;
   index: number;
-}): JSX.Element {
+}): JSX.Element => {
   return (
     <tr className={index % 2 === 0 ? 'evenRow' : 'oddRow'}>
       <td>{data.createdAt}</td>
@@ -17,7 +17,7 @@ function FillEventRow({
       <td>{data.price}</td>
     </tr>
   );
-}
+};
 
 export const ListFillEvents = (): JSX.Element => {
   const fillEvents: FillEvent[] = useFillEventQuery().data ?? [];

--- a/src/components/FillEvents/ListFillEvents.tsx
+++ b/src/components/FillEvents/ListFillEvents.tsx
@@ -1,0 +1,54 @@
+import { useFillEventQuery } from '../../lib/queries/FillEventQuery';
+import { FillEvent } from '../../lib/apiRequests/fillEventRequests';
+
+function FillEventRow ({ data, index }: { data: FillEvent, index: number }): JSX.Element {
+  return <tr
+      className={index % 2 === 0 ? 'evenRow' : 'oddRow'}
+  >
+    <td>{data.createdAt}</td>
+    <td>{data.cylinderSetName}</td>
+    <td>{data.gasMixture}</td>
+    <td>{data.description}</td>
+    <td>{data.price}</td>
+  </tr>;
+}
+
+export const ListFillEvents = (): JSX.Element => {
+  const fillEvents: FillEvent[] = useFillEventQuery().data ?? [];
+
+  return (
+    <div>
+      <h1 className="pb-4">Täyttötapahtumat</h1>
+      <table className="table">
+        <thead className="tableHead">
+          <tr>
+            <th>
+              Päivämäärä
+            </th>
+            <th>
+              pullosetti
+            </th>
+            <th>
+              kaasuseos
+            </th>
+            <th>
+              lisätiedot
+            </th>
+            <th>
+              hinta (€)
+            </th>
+          </tr>
+        </thead>
+        <tbody>
+          {fillEvents.map((fillEvent, index) =>
+              <FillEventRow
+                  key={fillEvent.id}
+                  data={fillEvent}
+                  index={index}
+              />
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};

--- a/src/components/FillEvents/ListFillEvents.tsx
+++ b/src/components/FillEvents/ListFillEvents.tsx
@@ -1,5 +1,5 @@
 import { useFillEventQuery } from '../../lib/queries/FillEventQuery';
-import { FillEvent } from '../../lib/apiRequests/fillEventRequests';
+import FillEvent from '../../interfaces/FillEvent';
 
 function FillEventRow ({ data, index }: { data: FillEvent, index: number }): JSX.Element {
   return <tr

--- a/src/interfaces/FillEvent.ts
+++ b/src/interfaces/FillEvent.ts
@@ -1,0 +1,12 @@
+export type FillEvent = {
+  id: string;
+  userId: string;
+  cylinderSetId: string;
+  cylinderSetName: string;
+  gasMixture: string;
+  description: string;
+  price: number;
+  createdAt: string;
+};
+
+export default FillEvent;

--- a/src/lib/apiRequests/fillEventRequests.ts
+++ b/src/lib/apiRequests/fillEventRequests.ts
@@ -1,15 +1,5 @@
 import { authGetAsync } from './api';
-
-export type FillEvent = {
-  id: string;
-  userId: string;
-  cylinderSetId: string;
-  cylinderSetName: string;
-  gasMixture: string;
-  description: string;
-  price: number;
-  createdAt: string;
-};
+import FillEvent from '../../interfaces/FillEvent';
 
 export const getFillEvents = async (): Promise<FillEvent[]> => {
   const response = await authGetAsync<FillEvent[]>(

--- a/src/lib/apiRequests/fillEventRequests.ts
+++ b/src/lib/apiRequests/fillEventRequests.ts
@@ -2,9 +2,7 @@ import { authGetAsync } from './api';
 import FillEvent from '../../interfaces/FillEvent';
 
 export const getFillEvents = async (): Promise<FillEvent[]> => {
-  const response = await authGetAsync<FillEvent[]>(
-    '/api/fill-event/'
-  );
+  const response = await authGetAsync<FillEvent[]>('/api/fill-event/');
 
   return response.data;
 };

--- a/src/lib/apiRequests/fillEventRequests.ts
+++ b/src/lib/apiRequests/fillEventRequests.ts
@@ -1,0 +1,20 @@
+import { authGetAsync } from './api';
+
+export type FillEvent = {
+  id: string;
+  userId: string;
+  cylinderSetId: string;
+  cylinderSetName: string;
+  gasMixture: string;
+  description: string;
+  price: number;
+  createdAt: string;
+};
+
+export const getFillEvents = async (): Promise<FillEvent[]> => {
+  const response = await authGetAsync<FillEvent[]>(
+    '/api/fill-event/'
+  );
+
+  return response.data;
+};

--- a/src/lib/queries/FillEventQuery.ts
+++ b/src/lib/queries/FillEventQuery.ts
@@ -13,7 +13,6 @@ export const useFillEventQuery = (): UseQuery<FillEvent[]> => {
       toast.error('Täyttötapahtumien hakeminen epäonnistui. Yritä uudelleen.');
     },
     retry: 1,
-    staleTime: 1000 * 60 * 60, // One hour
   });
 
   return {

--- a/src/lib/queries/FillEventQuery.ts
+++ b/src/lib/queries/FillEventQuery.ts
@@ -1,0 +1,26 @@
+import { useQuery } from '@tanstack/react-query';
+import { toast } from 'react-toastify';
+import {
+  FillEvent,
+  getFillEvents,
+} from '../apiRequests/fillEventRequests';
+import { UseQuery } from './common';
+import { FILL_EVENT_QUERY_KEY } from './queryKeys';
+
+export const useFillEventQuery = (): UseQuery<FillEvent[]> => {
+  const { isLoading, data, isError } = useQuery({
+    queryKey: FILL_EVENT_QUERY_KEY,
+    queryFn: async () => getFillEvents(),
+    onError: () => {
+      toast.error('Täyttötapahtumien hakeminen epäonnistui. Yritä uudelleen.');
+    },
+    retry: 1,
+    staleTime: 1000 * 60 * 60, // One hour
+  });
+
+  return {
+    data,
+    isLoading,
+    isError,
+  };
+};

--- a/src/lib/queries/FillEventQuery.ts
+++ b/src/lib/queries/FillEventQuery.ts
@@ -1,9 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
-import {
-  FillEvent,
-  getFillEvents,
-} from '../apiRequests/fillEventRequests';
+import { getFillEvents } from '../apiRequests/fillEventRequests';
+import FillEvent from '../../interfaces/FillEvent';
 import { UseQuery } from './common';
 import { FILL_EVENT_QUERY_KEY } from './queryKeys';
 

--- a/src/lib/queries/queryKeys.ts
+++ b/src/lib/queries/queryKeys.ts
@@ -11,4 +11,7 @@ export const CYLINDER_SETS_QUERY_KEY = (userId: string): string[] => [
 // Storage cylinder query keys
 export const STORAGE_CYLINDERS_QUERY_KEY = ['storageCylinder'];
 
+// Fill event related query keys
+export const FILL_EVENT_QUERY_KEY = ['fillEvents'];
+
 // ...

--- a/src/views/FillEvents.tsx
+++ b/src/views/FillEvents.tsx
@@ -1,0 +1,6 @@
+import { ListFillEvents } from '../components/FillEvents/ListFillEvents';
+import '../styles/blenderLogbook/blenderLogBook.css';
+
+export const FillEvents = (): JSX.Element => {
+  return (<ListFillEvents />);
+};

--- a/src/views/FillEvents.tsx
+++ b/src/views/FillEvents.tsx
@@ -1,6 +1,4 @@
 import { ListFillEvents } from '../components/FillEvents/ListFillEvents';
 import '../styles/blenderLogbook/blenderLogBook.css';
 
-export const FillEvents = (): JSX.Element => {
-  return (<ListFillEvents />);
-};
+export const FillEvents = (): JSX.Element => <ListFillEvents />;

--- a/src/views/Navbar.tsx
+++ b/src/views/Navbar.tsx
@@ -33,6 +33,7 @@ export const Navbar = (): JSX.Element | null => {
           <CustomLink to="/logbook">Paineilmatäyttö</CustomLink>
           <CustomLink to="/blender-logbook">Happihäkki</CustomLink>
           <CustomLink to="/diving-cylinder-set">Omat pullot</CustomLink>
+          <CustomLink to="/fill-events">Täyttötapahtumat</CustomLink>
 
           {/* Not part of the MVP
           <CustomLink to="/management">Käyttäjän hallinta</CustomLink>


### PR DESCRIPTION
Tää lista voidaan tulla ehkä siirtämään johonkin toiseen paikkaan tai sitten se tehdään kokonaan uudestaan erikseen seoskaasutäytöille ja paineilmatäytöille. Tämä kuitenkin voisi olla hyvä MVP-ratkaisu.

Tämä PR käyttää PR:ssä [#63](https://github.com/Tampereen-Urheilusukeltajat/Blenderi-Backend/pull/63) lisättyjä ominaisuuksia.

![image](https://user-images.githubusercontent.com/45848534/216533498-a9f2dd08-2453-46de-94cf-7d63043ad9e7.png)
