### PR TITLE
Send air filling events to backend

### DIFF
--- a/src/components/DivingCylinderSet/DivingCylinderSetList.tsx
+++ b/src/components/DivingCylinderSet/DivingCylinderSetList.tsx
@@ -1,5 +1,8 @@
 import { useMemo } from 'react';
-import { DivingCylinderSet } from '../../interfaces/DivingCylinderSet';
+import {
+  DivingCylinder,
+  DivingCylinderSet,
+} from '../../interfaces/DivingCylinderSet';
 import { useDivingCylinderQuery } from '../../lib/queries/divingCylinderQuery';
 import { getUserIdFromAccessToken } from '../../lib/utils';
 import { CommonTable, TableColumn, TableRow } from '../common/Table';
@@ -47,7 +50,7 @@ const DCMaterialFiTranslation = (enMaterial: string): string => {
 const divingCylinderSetsToCommonTableRows = (
   divingCylinderSets: DivingCylinderSet[]
 ): TableRow[] => {
-  return divingCylinderSets.map((dcs) => {
+  return divingCylinderSets.map((dcs: DivingCylinderSet) => {
     // Single cylinder so only return mainRow
     if (dcs.cylinders.length === 1) {
       const dc = dcs.cylinders[0];
@@ -64,12 +67,12 @@ const divingCylinderSetsToCommonTableRows = (
     }
 
     const totalSetVolume = dcs.cylinders
-      .map((dc) => dc.volume)
-      .reduce((pv, cv) => (pv += cv));
+      .map((dc: DivingCylinder) => dc.volume)
+      .reduce((acc, cv) => acc + cv);
     return {
       mainRow: [dcs.name, totalSetVolume, null, null, null, null],
       childRows: [
-        ...dcs.cylinders.map((dc) => [
+        ...dcs.cylinders.map((dc: DivingCylinder) => [
           null,
           dc.volume,
           DCMaterialFiTranslation(dc.material),

--- a/src/components/DivingCylinderSet/NewDivingCylinderSet.tsx
+++ b/src/components/DivingCylinderSet/NewDivingCylinderSet.tsx
@@ -20,9 +20,9 @@ import { NEW_CYLINDER_SET_VALIDATION_SCHEMA } from './validation';
 import { TextInput, DropdownMenu } from '../common/Inputs';
 
 const EmptyDivingCylinder: Omit<DivingCylinder, 'id'> = {
-  volume: '',
+  volume: 0,
   material: 'steel',
-  pressure: '',
+  pressure: 0,
   serialNumber: '',
   inspection: '',
 };

--- a/src/components/Logbook/FillingTile.tsx
+++ b/src/components/Logbook/FillingTile.tsx
@@ -11,9 +11,7 @@ import { getUserIdFromAccessToken } from '../../lib/utils';
 
 type LogbookFillingEventRowProps = LogbookCommonTileProps & {
   index: number;
-  replace: (index: number, newValue: unknown) => void;
   remove: (index: number) => void;
-  push: (value: unknown) => void;
   setFieldValue: (
     field: string,
     value: unknown,
@@ -31,7 +29,7 @@ type AirLogbookFillingTileProps = LogbookCommonTileProps & {
 
 export const LogbookFillingEventRowComponent: React.FC<
   LogbookFillingEventRowProps
-> = ({ index, errors, values, replace, remove, push }) => {
+> = ({ index, errors, values, remove }) => {
   const userId = useMemo(() => getUserIdFromAccessToken(), []);
 
   const divingCylinderSets: DivingCylinderSet[] =
@@ -53,27 +51,9 @@ export const LogbookFillingEventRowComponent: React.FC<
         <IconButton
           className="deleteRowButton"
           icon={<BsTrash />}
-          onClick={() =>
-            index === 0
-              ? replace(index, {
-                  ...EMPTY_LOGBOOK_FILLING_EVENT_ROW,
-                })
-              : remove(index)
-          }
+          onClick={() => remove(index)}
         />
       </div>
-      {values.fillingEventRows.length === index + 1 ? (
-        <PrimaryButton
-          className="addNewRow"
-          onClick={() =>
-            push({
-              ...EMPTY_LOGBOOK_FILLING_EVENT_ROW,
-            })
-          }
-          type={ButtonType.button}
-          text="Lisää uusi rivi"
-        />
-      ) : null}
     </div>
   );
 };
@@ -98,13 +78,21 @@ export const LogbookFillingTile: React.FC<AirLogbookFillingTileProps> = ({
                 key={index}
                 errors={errors}
                 index={index}
-                push={push}
                 remove={remove}
-                replace={replace}
                 setFieldValue={setFieldValue}
                 values={values}
               />
             ))}
+            <PrimaryButton
+              className="addNewRow"
+              onClick={() =>
+                push({
+                  ...EMPTY_LOGBOOK_FILLING_EVENT_ROW,
+                })
+              }
+              type={ButtonType.button}
+              text="Lisää uusi rivi"
+            />
           </>
         )}
       </FieldArray>

--- a/src/components/Logbook/NewFillingEvent.tsx
+++ b/src/components/Logbook/NewFillingEvent.tsx
@@ -43,7 +43,7 @@ export const NewFillingEvent = (): JSX.Element => {
       await fillEventMutation.mutate(
         {
           cylinderSetId: divingCylinderSet,
-          gasMixture: 'Paineilma',
+          gasMixture: 'EAN21',
           filledAir: true,
           description: values.additionalInformation,
           price: 0,

--- a/src/components/Logbook/validation.ts
+++ b/src/components/Logbook/validation.ts
@@ -1,4 +1,5 @@
 import * as yup from 'yup';
+import { FIELD_REQUIRED } from '../UserSettings/validation';
 
 export const AIR_FILLING_EVENT_VALIDATION_SCHEMA = yup.object().shape({
   additionalInformation: yup.string().optional(),
@@ -7,7 +8,7 @@ export const AIR_FILLING_EVENT_VALIDATION_SCHEMA = yup.object().shape({
     .array()
     .of(
       yup.object().shape({
-        divingCylinderSet: yup.string().required(),
+        divingCylinderSet: yup.string().required(FIELD_REQUIRED),
       })
     )
     .required()

--- a/src/components/common/Inputs.tsx
+++ b/src/components/common/Inputs.tsx
@@ -85,7 +85,9 @@ export const DropdownMenu: React.FC<SelectInputProps> = ({
           name={name}
           placeholder={placeholder}
           type={type}
+          defaultValue={undefined}
         >
+          <option hidden value={undefined}></option>
           {children}
         </Field>
         {unit !== undefined ? <InputGroup.Text>{unit}</InputGroup.Text> : null}

--- a/src/interfaces/DivingCylinderSet.ts
+++ b/src/interfaces/DivingCylinderSet.ts
@@ -1,8 +1,8 @@
 export type DivingCylinder = {
   id: string;
-  volume: string;
+  volume: number;
   material: string;
-  pressure: string;
+  pressure: number;
   serialNumber: string;
   inspection: string;
 };

--- a/src/interfaces/FillEvent.ts
+++ b/src/interfaces/FillEvent.ts
@@ -8,3 +8,23 @@ export type FillEvent = {
   price: number;
   createdAt: string;
 };
+
+type storageCylinderUsage = {
+  storageCylinderId: number;
+  startPressure: number;
+  endPressure: number;
+};
+
+export type NewFillEvent = {
+  cylinderSetId: string;
+  gasMixture: string;
+  filledAir: boolean;
+  description: string;
+  price: number;
+  storageCylinderUsageArr: storageCylinderUsage[];
+};
+
+export type CreatedFillEvent = NewFillEvent & {
+  id: string;
+  userId: string;
+};

--- a/src/lib/apiRequests/fillEventRequests.ts
+++ b/src/lib/apiRequests/fillEventRequests.ts
@@ -1,5 +1,19 @@
-import { authGetAsync } from './api';
-import { FillEvent } from '../../interfaces/FillEvent';
+import { authGetAsync, authPostAsync } from './api';
+import {
+  FillEvent,
+  CreatedFillEvent,
+  NewFillEvent,
+} from '../../interfaces/FillEvent';
+
+export const postFillEvent = async (
+  payload: NewFillEvent
+): Promise<CreatedFillEvent> => {
+  const response = await authPostAsync<CreatedFillEvent, NewFillEvent>(
+    '/api/fill-event/',
+    payload
+  );
+  return response.data;
+};
 
 export const getFillEvents = async (): Promise<FillEvent[]> => {
   const response = await authGetAsync<FillEvent[]>('/api/fill-event/');

--- a/src/lib/queries/FillEventQuery.ts
+++ b/src/lib/queries/FillEventQuery.ts
@@ -1,7 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { toast } from 'react-toastify';
-import { getFillEvents } from '../apiRequests/fillEventRequests';
-import { FillEvent } from '../../interfaces/FillEvent';
+import { getFillEvents, postFillEvent } from '../apiRequests/fillEventRequests';
+import {
+  FillEvent,
+  CreatedFillEvent,
+  NewFillEvent,
+} from '../../interfaces/FillEvent';
 import { UseQuery } from './common';
 import { FILL_EVENT_QUERY_KEY } from './queryKeys';
 
@@ -11,6 +15,26 @@ export const useFillEventQuery = (): UseQuery<FillEvent[]> => {
     queryFn: async () => getFillEvents(),
     onError: () => {
       toast.error('Täyttötapahtumien hakeminen epäonnistui. Yritä uudelleen.');
+    },
+    retry: 1,
+  });
+
+  return {
+    data,
+    isLoading,
+    isError,
+  };
+};
+
+export const useNewFillEventQuery = (
+  payload: NewFillEvent
+): UseQuery<CreatedFillEvent> => {
+  const { isLoading, data, isError } = useQuery({
+    queryFn: async () => postFillEvent(payload),
+    onError: () => {
+      toast.error(
+        'Täyttötapahtuman tallentaminen epäonnistui. Yritä uudelleen.'
+      );
     },
     retry: 1,
   });

--- a/src/lib/queries/queryKeys.ts
+++ b/src/lib/queries/queryKeys.ts
@@ -13,5 +13,6 @@ export const STORAGE_CYLINDERS_QUERY_KEY = ['storageCylinder'];
 
 // Fill event related query keys
 export const FILL_EVENT_QUERY_KEY = ['fillEvents'];
+export const BARE_FILL_EVENT_QUERY_KEY = ['bareFillEvents'];
 
 // ...


### PR DESCRIPTION
Ja tää kannattaa taas tosiaan kattoa commit kerrallaan.

Tehtyjä kompromisseja:
- Ilmatäyttöjen lähettäminen backendiin ei ole nyt atominen operaatio. Sen ehkä pitäisi olla. Tämä ei kuitenkaan estä testikäyttöä.
- Tyyppejä haetaan hämmentävästi blenderLogbookin tiedostoista. Tämä refaktorointi on ihan oman PR:nsä arvoinen.