### PR TITLE
Redirect to root url after password reset request

### DIFF
--- a/src/components/PasswordResetRequest/PasswordResetRequestForm.tsx
+++ b/src/components/PasswordResetRequest/PasswordResetRequestForm.tsx
@@ -15,7 +15,7 @@ export const PasswordResetRequestForm: React.FC = () => {
   const navigate = useNavigate();
 
   const handleSuccessfulPasswordResetRequest = useCallback(() => {
-    navigate('/login');
+    navigate('/');
   }, [navigate]);
 
   const { mutate } = usePasswordResetRequestMutation(


### PR DESCRIPTION
This is done because redirecting to "/login"
causes error in nawbar rendering.
So kinda workaround.