### PR TITLE
UX improvements for sessions and GDPR page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -58,7 +58,7 @@ const Content: React.FC = () => {
         <Route element={<BaseElement />}>
           {/* Public routes */}
           <Route element={<FrontPage />}>
-            <Route path="/" element={<Login />} />
+            <Route path="login" element={<Login />} />
             <Route path="register" element={<Register />} />
             <Route
               path={'request-password-reset'}
@@ -86,7 +86,7 @@ const Content: React.FC = () => {
           </Route>
 
           {/* 404 */}
-          <Route path="*" element={<Navigate to="/" />} />
+          <Route path="*" element={<Navigate to="/logbook" />} />
         </Route>
       </Routes>
     </main>

--- a/src/components/Footer/Footer.tsx
+++ b/src/components/Footer/Footer.tsx
@@ -2,14 +2,17 @@ import React from 'react';
 import styles from './Footer.module.scss';
 import Tayttopaikka from '../../svg/tayttopaikka.svg?react';
 import happihakkiInstructions from '../../Files/happihakki-instructions.pdf';
+import { Link } from 'react-router-dom';
 
 export const Footer: React.FC = () => {
   return (
     <div className={styles.footer}>
       <div className={styles.row}>
-        <div className={styles.logo}>
-          <Tayttopaikka />
-        </div>
+        <Link to="/logbook">
+          <div className={styles.logo}>
+            <Tayttopaikka />
+          </div>
+        </Link>
       </div>
       <div className={styles.row}>
         <a href="https://taursu.fi" className={styles.item}>
@@ -20,9 +23,9 @@ export const Footer: React.FC = () => {
         </a>
       </div>
       <div className={styles.row}>
-        <a href="/gdpr" className={styles.item}>
+        <Link to="/gdpr" className={styles.item}>
           Tietosuojaseloste
-        </a>
+        </Link>
         <a href={happihakkiInstructions} download className={styles.item}>
           Happihäkin ohjeet
         </a>

--- a/src/components/Navbar/Navbar.tsx
+++ b/src/components/Navbar/Navbar.tsx
@@ -19,7 +19,7 @@ export const Navbar: React.FC = () => {
     // Invalidate React Query cache
     queryClient.clear();
 
-    navigate('/');
+    navigate('/login');
   }, [navigate, queryClient]);
 
   const { isAdmin, isBlender } = getUserRoles();

--- a/src/components/PasswordResetRequest/PasswordResetRequestForm.tsx
+++ b/src/components/PasswordResetRequest/PasswordResetRequestForm.tsx
@@ -15,7 +15,7 @@ export const PasswordResetRequestForm: React.FC = () => {
   const navigate = useNavigate();
 
   const handleSuccessfulPasswordResetRequest = useCallback(() => {
-    navigate('/');
+    navigate('/login');
   }, [navigate]);
 
   const { mutate } = usePasswordResetRequestMutation(

--- a/src/components/common/Auth.tsx
+++ b/src/components/common/Auth.tsx
@@ -44,13 +44,13 @@ export const ProtectedRoute: React.FC<PrivateRouteProps> = ({
         }
       })
       .catch(() => {
-        navigate('/');
+        navigate('/login');
       });
   }, [navigate, blenderOnly, adminOnly]);
 
   useEffect(() => {
     if (!loading && !authenticated) {
-      navigate('/');
+      navigate('/login');
     }
   }, [authenticated, loading, navigate]);
 

--- a/src/lib/queries/registerMutation.ts
+++ b/src/lib/queries/registerMutation.ts
@@ -23,7 +23,7 @@ export const useRegisterMutation = (): UseMutation<
     },
     onSuccess: () => {
       toast.success('Rekistöröityminen onnistui! Kirjaudu sisään.');
-      navigate('/');
+      navigate('/login');
     },
   });
 

--- a/src/views/FrontPage/FrontPage.tsx
+++ b/src/views/FrontPage/FrontPage.tsx
@@ -10,7 +10,7 @@ export const FrontPage: React.FC = () => {
   const [showBackButton, setShowBackButton] = useState(false);
   const location = useLocation();
   useEffect(() => {
-    setShowBackButton(location.pathname !== '/');
+    setShowBackButton(location.pathname !== '/login');
   }, [location]);
 
   return (
@@ -18,7 +18,7 @@ export const FrontPage: React.FC = () => {
       <div className={styles.content}>
         <div className={styles.contentPart}>
           {showBackButton && (
-            <Link className={styles.styledLink} to={'/'}>
+            <Link className={styles.styledLink} to={'/login'}>
               <BsArrowLeftCircle />
             </Link>
           )}

--- a/src/views/GDPR.tsx
+++ b/src/views/GDPR.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 export const GDPR: React.FC = () => {
   return (
-    <div>
+    <div className="p-4">
       <h1>Rekisteri- ja tietosuojaseloste</h1>
       <h2>
         Tämä on Tampereen Urheilusukeltajat ry:n (Taursu) EU:n yleisen


### PR DESCRIPTION
- Make GDPR site to use app router instead of HTML a element, which loads the whole app again.
- Make Tayttopaikka logo in the bottom clickable, so user can return from GDPR site
- Route user automatically to protected site, if they  have a valid session ongoing. No longer opening the root route requires user to relogin